### PR TITLE
Building on Linux and MD 5 compatibility 

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-xbuild /t:Build /p:Configuration=Debug MonoDevelop.AddinMaker.sln || exit 1
-xbuild /t:InstallAddin /p:Configuration=Debug MonoDevelop.AddinMaker.csproj || exit 1
+xbuild /t:Build /p:Configuration=Release MonoDevelop.AddinMaker.sln || exit 1
+# xbuild /t:InstallAddin /p:Configuration=Release MonoDevelop.AddinMaker.csproj || exit 1
 

--- a/MonoDevelop.AddinMaker.csproj
+++ b/MonoDevelop.AddinMaker.csproj
@@ -30,8 +30,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
+    <Reference Include="MonoDevelop.DesignerSupport, Version=2.6.0.0, Culture=neutral">
+      <Package>monodevelop-core-addins</Package>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Manifest.addin.xml">
@@ -70,10 +72,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <AddinReference Include="MonoDevelop.DesignerSupport" />
-  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="MonoDevelop.Addins.Tasks\bin\$(Configuration)\MonoDevelop.Addins.targets"
-      Condition="Exists('MonoDevelop.Addins.Tasks\bin\$(Configuration)\MonoDevelop.Addins.targets')"/>
+  <Import Project="MonoDevelop.Addins.Tasks\bin\$(Configuration)\MonoDevelop.Addins.targets" Condition="Exists('MonoDevelop.Addins.Tasks\bin\$(Configuration)\MonoDevelop.Addins.targets')" />
 </Project>

--- a/MonoDevelop.Addins.Tasks/GetDefaultMonoDevelopLocations.cs
+++ b/MonoDevelop.Addins.Tasks/GetDefaultMonoDevelopLocations.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace MonoDevelop.Addins.Tasks
 {
@@ -82,16 +83,39 @@ namespace MonoDevelop.Addins.Tasks
 					BinDir = "/Applications/Xamarin Studio.app/Contents/MacOS/lib/monodevelop/bin";
 				}
 			} else {
-				string checkDir = Environment.GetEnvironmentVariable ("LD_LIBRARY_PATH").TrimStart(':');
-				if (!checkDir.Contains("monodevelop/bin")) {
-					checkDir += "/monodevelop/bin";
-				}
-
-				BinDir = checkDir;
+				BinDir = GetBinDir(Environment.GetEnvironmentVariable("LD_LIBRARY_PATH"));
 			}
 
 			//TODO: check locations are valid
 			return true;
+		}
+
+		private string GetBinDir(string libraryPaths) {
+			//string libraryPaths = Environment.GetEnvironmentVariable ("LD_LIBRARY_PATH");
+			List<string> tempDir = new List<string> ();
+			string dir = "";
+
+			int pos = 1;
+			bool foundColon = false;
+
+
+			if(libraryPaths.Contains("monodevelop/lib") && !libraryPaths.Contains("monodevelop/bin")) {
+				while(!foundColon) {
+					if(libraryPaths[libraryPaths.IndexOf("monodevelop/lib")-pos] != ':') {
+						tempDir.Insert (0, libraryPaths [libraryPaths.IndexOf ("monodevelop/lib") - pos].ToString ());
+						pos++;
+					} else {
+						foundColon = true;
+						tempDir.Add ("monodevelop/lib/monodevelop/bin");
+					}
+				}
+			}
+
+			foreach(string s in tempDir) {
+				dir += s;
+			}
+
+			return dir;
 		}
 
 		[Output]

--- a/MonoDevelop.Addins.Tasks/GetDefaultMonoDevelopLocations.cs
+++ b/MonoDevelop.Addins.Tasks/GetDefaultMonoDevelopLocations.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Diagnostics;
 
 namespace MonoDevelop.Addins.Tasks
 {
@@ -81,7 +82,12 @@ namespace MonoDevelop.Addins.Tasks
 					BinDir = "/Applications/Xamarin Studio.app/Contents/MacOS/lib/monodevelop/bin";
 				}
 			} else {
-				BinDir = "/usr/lib/monodevelop/bin";
+				string checkDir = Environment.GetEnvironmentVariable ("LD_LIBRARY_PATH").TrimStart(':');
+				if (!checkDir.Contains("monodevelop/bin")) {
+					checkDir += "/monodevelop/bin";
+				}
+
+				BinDir = checkDir;
 			}
 
 			//TODO: check locations are valid

--- a/MonoDevelop.Addins.Tasks/MonoDevelop.Addins.Tasks.csproj
+++ b/MonoDevelop.Addins.Tasks/MonoDevelop.Addins.Tasks.csproj
@@ -28,17 +28,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="Mono.Addins">
-      <HintPath>..\packages\Mono.Addins.1.1\lib\Mono.Addins.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
-    <Reference Include="Mono.Addins.Setup">
-      <HintPath>..\packages\Mono.Addins.Setup.1.1\lib\Mono.Addins.Setup.dll</HintPath>
+    <Reference Include="ICSharpCode.SharpZipLib" />
+    <Reference Include="Mono.Addins">
+      <HintPath>..\packages\Mono.Addins.1.2\lib\net40\Mono.Addins.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\packages\Mono.Addins.Setup.1.1\lib\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="Mono.Addins.Setup">
+      <HintPath>..\packages\Mono.Addins.Setup.1.2\lib\net40\Mono.Addins.Setup.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/MonoDevelop.Addins.Tasks/MonoDevelop.Addins.targets
+++ b/MonoDevelop.Addins.Tasks/MonoDevelop.Addins.targets
@@ -54,7 +54,7 @@
     <Reference Include="pango-sharp">
         <Private>False</Private>
     </Reference>
-    <Reference Include="xwt">
+    <Reference Include="Xwt">
         <Private>False</Private>
     </Reference>
     <Reference Include="IKVM.Reflection">
@@ -124,6 +124,7 @@
       </CreatePackage>
   </Target>
 
+  <!--
   <Target Name="InstallAddin" DependsOnTargets="CreatePackage">
     <PropertyGroup>
       <_MDToolCommand>"$(MDToolExe)"</_MDToolCommand>
@@ -131,6 +132,7 @@
     </PropertyGroup>
     <Exec Command='$(_MDToolCommand) setup install -y "$(PackageFile)"' StandardOutputImportance="Low" />
   </Target>
+  -->
 
   <PropertyGroup>
     <CoreCompileDependsOn>

--- a/MonoDevelop.Addins.Tasks/packages.config
+++ b/MonoDevelop.Addins.Tasks/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Mono.Addins" version="1.2" targetFramework="net40" />
   <package id="Mono.Addins.Setup" version="1.2" targetFramework="net40" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net40" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 This MonoDevelop addin makes it easy to create and maintain MonoDevelop addins.
 
 To build and install from source, simply run `Install.bat` (Windows) or `Install.sh` (Mac, Linux).
+
+On Linux, the script will create a package that you can install from inside the MonoDevelop editor under Tools->Add-in Manager->Install from file.
+
+Ensure that your LD_LIBRARY_PATH is set to allow your monodevelop library to be found. eg: '/opt/monodevelop/lib'

--- a/addin-project.xml
+++ b/addin-project.xml
@@ -2,6 +2,6 @@
 	<Project platforms="Win32 Mac Linux">
 		<AddinFile>bin/Debug/MonoDevelop.AddinMaker.dll</AddinFile>
 		<BuildFile>MonoDevelop.AddinMaker.sln</BuildFile>
-		<BuildConfiguration>Debug</BuildConfiguration>
+		<BuildConfiguration>Release</BuildConfiguration>
 	</Project>
 </AddinProject>


### PR DESCRIPTION
Attempted to fix building the addin on linux machines by grabbing the bin directory using LD_LIBRARY_PATH (which it seems should be set when installing Monodevelop).
If not, it can easily be set.

The new addin is built with MD 5, too, so it should be compatible with new versions if the package is added to the public addin repositories.
