### PR TITLE
Track Roslyn branch API changes

### DIFF
--- a/AddinBrowser/AddinBrowserWidget.cs
+++ b/AddinBrowser/AddinBrowserWidget.cs
@@ -11,11 +11,12 @@ namespace MonoDevelop.AddinMaker.AddinBrowser
 		public AddinBrowserWidget (AddinRegistry registry)
 		{
 			TreeView = new AddinTreeView (registry);
+			var gtkTreeView = TreeView.GetNativeWidget<Gtk.Widget> ();
 
-			TreeView.Tree.Selection.Mode = SelectionMode.Single;
-			TreeView.WidthRequest = 300;
+			TreeView.AllowsMultipleSelection = false;
+			gtkTreeView.WidthRequest = 300;
 
-			Pack1 (TreeView, false, false);
+			Pack1 (gtkTreeView, false, false);
 			SetDetail (null);
 
 			ShowAll ();


### PR DESCRIPTION
ExtensibleTreeView is now MD.Control & Tree is now internal..

In theory this is future compatible in case ExtensibleTreeView implemtation changes to different implementation since GetNativeWidget takes care of embedding Mac/WPF into GTK# control...
