### PR TITLE
Fix MDBinDir not output in build error message.

### DIFF
--- a/MonoDevelop.Addins.Tasks/MonoDevelop.Addins.targets
+++ b/MonoDevelop.Addins.Tasks/MonoDevelop.Addins.targets
@@ -99,7 +99,7 @@
       <_MDToolCommand Condition="'$(OS)'=='Unix'">mono "$(MDToolExe)"</_MDToolCommand>
     </PropertyGroup>
 
-    <Error Text = "Bin directory not found: $(BinDir)" Condition="!Exists('$(MDToolExe)')" />
+    <Error Text = "Bin directory not found: $(MDBinDir)" Condition="!Exists('$(MDToolExe)')" />
 
     <PropertyGroup>  
       <AssemblySearchPaths>$(MDBinDir);$(AssemblySearchPaths)</AssemblySearchPaths>


### PR DESCRIPTION
When using an MDBinDir property that points to a directory that does
not exist the build error was not displaying the MDBinDir value.
