### PR TITLE
Support a custom addin output directory

### DIFF
--- a/AddinProjectFlavor.cs
+++ b/AddinProjectFlavor.cs
@@ -55,9 +55,18 @@ namespace MonoDevelop.AddinMaker
 			var cmd = (DotNetExecutionCommand) base.OnCreateExecutionCommand (configSel, configuration);
 			cmd.Command = Assembly.GetEntryAssembly ().Location;
 			cmd.Arguments = "--no-redirect";
-			cmd.EnvironmentVariables["MONODEVELOP_DEV_ADDINS"] = Project.GetOutputFileName (configSel).ParentDirectory;
+			cmd.EnvironmentVariables["MONODEVELOP_DEV_ADDINS"] = GetAddinOutputDirectory (configSel, configuration);
 			cmd.EnvironmentVariables ["MONODEVELOP_CONSOLE_LOG_LEVEL"] = "All";
 			return cmd;
+		}
+
+		string GetAddinOutputDirectory (ConfigurationSelector configSel, DotNetProjectConfiguration configuration)
+		{
+			FilePath outputPath = configuration.EvaluatedProperties.GetPathValue ("AddinOutputPath");
+			if (outputPath.IsNotNull)
+				return outputPath;
+
+			return Project.GetOutputFileName (configSel).ParentDirectory;
 		}
 
 		protected override bool OnGetCanExecute (ExecutionContext context, ConfigurationSelector configuration)

--- a/MonoDevelop.Addins.Tasks/MonoDevelop.Addins.targets
+++ b/MonoDevelop.Addins.Tasks/MonoDevelop.Addins.targets
@@ -128,13 +128,29 @@
   </Target>
 
   <Target Name="_CoreCreatePackage">
+    <PropertyGroup>
+      <HasCustomAddinOutputPath Condition=" '$(AddinOutputPath)' !='' ">true</HasCustomAddinOutputPath>
+      <AddinOutDir Condition=" '$(AddinOutDir)' == '' ">$(AddinOutputPath)</AddinOutDir>
+      <AddinOutDir Condition=" '$(AddinOutDir)' == '' ">$(OutDir)</AddinOutDir>
+      <AddinOutDir Condition="'$(AddinOutDir)' != '' and !HasTrailingSlash('$(AddinOutDir)')">$(AddinOutDir)\</AddinOutDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_AddinOutDirItem Include="$(AddinOutDir)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <AddinTargetPath Condition=" '$(AddinTargetPath)' == '' and '$(HasCustomAddinOutputPath)' == 'true'">@(_AddinOutDirItem->'%(FullPath)\$(TargetFileName)')</AddinTargetPath>
+      <AddinTargetPath Condition=" '$(AddinTargetPath)' == ''">$(TargetPath)</AddinTargetPath>
+    </PropertyGroup>
+
     <CreatePackage
       ConfigDir="$(MDConfigDir)"
       AddinsDir="$(MDAddinsDir)"
       DatabaseDir="$(MDDatabaseDir)"
       BinDir="$(MDBinDir)"
-      OutputDir="$(OutDir)"
-      AddinFile="$(TargetPath)">
+      OutputDir="$(AddinOutDir)"
+      AddinFile="$(AddinTargetPath)">
           <Output TaskParameter="PackageFile" PropertyName="PackageFile" />
       </CreatePackage>
     <!-- HACK: re-pack the addin since files packed directly by Mono.Addins can't
@@ -144,7 +160,7 @@
     to do with a using a registry that was built from an sh environemnt?
     -->
     <Exec Command='$(_MDToolCommand) setup rgb' />
-    <Exec Command='$(_MDToolCommand) setup pack "-d:$(OutDir)." "$(TargetPath)"' />
+    <Exec Command='$(_MDToolCommand) setup pack "-d:$(AddinOutDir)." "$(AddinTargetPath)"' />
   </Target>
 
   <Target Name="_CoreInstallAddin">


### PR DESCRIPTION
Allows the addin output directory to be changed with an AddinOutputPath property in the project.

When debugging the AddinOutputPath will be used.

When creating an .mpack the AddinOutputPath will be used.
