### PR TITLE
Avoid creating a new CecilReflectorExtension per file.

### DIFF
--- a/MonoDevelop.Addins.Tasks/AddinTask.cs
+++ b/MonoDevelop.Addins.Tasks/AddinTask.cs
@@ -79,17 +79,6 @@ namespace MonoDevelop.Addins.Tasks
 
 	class CecilReflectorExtension : AddinFileSystemExtension
 	{
-		//force it to use the cecil reflector. rhe SR one breaks easily under MSBuild
-		public override IAssemblyReflector GetReflectorForFile (IAssemblyLocator locator, string path)
-		{
-			string asmFile = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location), "Mono.Addins.CecilReflector.dll");
-			Assembly asm = Assembly.LoadFrom (asmFile);
-			Type t = asm.GetType ("Mono.Addins.CecilReflector.Reflector");
-			var reflector = (IAssemblyReflector)Activator.CreateInstance (t);
-			reflector.Initialize (locator);
-			return reflector;
-		}
-
 		//mono.addins uses an appdomain even when using the cecil reflector
 		//but that breaks us because the appdomain's base directory is the msbuild
 		//bindir so it can't load the assembly. force it to run inproc instead.

--- a/MonoDevelop.Addins.Tasks/ResolveMonoDevelopAddins.cs
+++ b/MonoDevelop.Addins.Tasks/ResolveMonoDevelopAddins.cs
@@ -128,6 +128,8 @@ namespace MonoDevelop.Addins.Tasks
 
 			ResolvedAddins = resolvedAddins.ToArray ();
 
+			Registry.Dispose();
+
 			return success;
 		}
 


### PR DESCRIPTION
The unwritten contract of AddinFileSystemExtension.GetReflectorForFile expects it to cache the Reflector, and the base implementation does that:
https://github.com/mono/mono-addins/blob/e84472dcd17b61a904538e1cc2e19f4b064c7068/Mono.Addins/Mono.Addins.Database/AddinFileSystemExtension.cs#L170

AddinScanner.Dispose() then calls database.FileSystem.CleanupReflector ();:
https://github.com/mono/mono-addins/blob/e84472dcd17b61a904538e1cc2e19f4b064c7068/Mono.Addins/Mono.Addins.Database/AddinScanner.cs#L58

This change does two things:
1. Dispose of the Registry after the ResolveMonoDevelopAddins task is done, which in turn disposes the Cecil Reflector
2. Removes the overridden GetReflectorForFile from CecilReflectorExtension since that is equivalent to the base implementation but without the caching. The base implementation does proper caching.

The fix has many benefits, such as:
1. Not allocating many file handles
2. Cleanup file handles after use
3. Improve build perf from 3.4 to 2.1 seconds on a solution with two addin projects

Fixes #55
Fixes #58